### PR TITLE
Update props spread, fix fill color, fix props type inference

### DIFF
--- a/src/.Layout.astro
+++ b/src/.Layout.astro
@@ -1,17 +1,16 @@
 ---
-export type { Props } from './index.d.ts'
+import type { Props } from './index.d.ts'
 
-const size = Astro.props.size
-delete Astro.props.size
+const { fill, size, ...props }:Props = Astro.props;
 ---
 
 <svg
-	xmlns="http://www.w3.org/2000/svg"
-	width={size ?? 24}
-	height={size ?? 24}
-	fill="currentColor"
-	viewBox="0 0 24 24"
-	{...Astro.props}
+  xmlns="http://www.w3.org/2000/svg"
+  width={size}
+  height={size}
+  viewBox=`0 0 ${size} ${size}`
+  fill={fill}
+  {...props}
 >
 	<slot />
 </svg>

--- a/src/Template.astro
+++ b/src/Template.astro
@@ -1,11 +1,15 @@
 ---
 import Layout from './.Layout.astro'
-export type { Props } from './index.d.ts'
+import type { Props } from './index.d.ts'
+
+delete Astro.props.slot;
+const { fill = '<!-- color -->', size = 24, ...props }:Props = Astro.props
 ---
 
 <Layout
-	fill="<!-- color -->"
-	{...Astro.props}
+size={size}
+fill={fill}
+{...props}
 >
 	<!-- icon -->
 </Layout>

--- a/src/build.js
+++ b/src/build.js
@@ -14,7 +14,7 @@ function fillTemplate(icon, color = '') {
 	return template.replace(
 		'<!-- icon -->',
 		icon.replace(/<svg(?:.|\n)*?>((?:.|\n)*)<\/svg>/gm, '$1').replace(/  /g, '\t').trim()
-	).replace('fill="<!-- color -->"', color ? `fill="#${color}"` : '')
+	).replace('<!-- color -->', color ? `#${color}` : '')
 }
 
 // copy the base layout


### PR DESCRIPTION
Changed `const size = Astro.props.size` to `const { size, ...props} = Astro.props` and then on the component changed `{....Astro.props}` to `{...props}`. This was causing certain properties to be overwritten and now will preserve any other SVG attributes passed in such as stroke.

Also updated the build.js file to only replace the color comment and not the full `fill=<!--color-->`;

Changed export type Props to import type Props so type-hinting could be inferred and allow SVG props to be passed in.

Also changed the 'currentColor' on the fill. No color was set on a parent element, so this  was not doing anything. 